### PR TITLE
Get flux-swarm working on multi-host clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ go get -u github.com/FiloSottile/gvt
 
 go get github.com/ContainerSolutions/flux
 cd $GOPATH/src/github.com/ContainerSolutions/flux
+git remote add lukefork https://github.com/lukemarsden/flux
+git fetch lukefork
+git checkout lukefork/master
 gvt restore
 make
 docker-compose up
@@ -37,7 +40,6 @@ cd ~/
 git clone https://github.com/ContainerSolutions/flux-demo
 cd ~/flux-demo
 
-docker swarm init
 for svc in *.yml; do docker deploy -c $svc default_swarm; done
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Will be putting it into the config file, once I find how to save in DB.
 
 * docker 1.12+
 
+Set up a swarm if you need to, using e.g. `docker swarm init`.
+
 ## Installation
 
 ```
@@ -29,9 +31,6 @@ go get -u github.com/FiloSottile/gvt
 
 go get github.com/ContainerSolutions/flux
 cd $GOPATH/src/github.com/ContainerSolutions/flux
-git remote add lukefork https://github.com/lukemarsden/flux
-git fetch lukefork
-git checkout lukefork/master
 gvt restore
 make
 docker-compose up

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -31,24 +31,7 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 		if ignore.Contains(ps.ID) {
 			continue
 		}
-		/// OLD
 		args := filters.NewArgs()
-		args.Add("label",
-			fmt.Sprintf("com.docker.swarm.service.name=%v", v.Spec.Annotations.Name),
-		)
-		cs, err := c.client.ContainerList(ctx, types.ContainerListOptions{Filters: args})
-		if err != nil {
-			return pss, err
-		}
-		oldPcs := make([]platform.Container, len(cs))
-		for k, v := range cs {
-			oldPcs[k] = platform.Container{
-				Name:  v.Labels["com.docker.swarm.task.name"],
-				Image: v.Image,
-			}
-		}
-		/// NEW
-		args = filters.NewArgs()
 		args.Add("service", v.ID)
 		ts, err := c.client.TaskList(ctx, types.TaskListOptions{Filters: args})
 		if err != nil {
@@ -61,13 +44,6 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 				Image: t.Spec.ContainerSpec.Image,
 			}
 		}
-
-		/// LOG
-		fmt.Printf(
-			"[AllServices] %s: OLD: %v, NEW: %v; ts=%+v\n",
-			v.Spec.Name, oldPcs, pcs, ts,
-		)
-
 		ps.Containers.Containers = pcs
 		pss[k] = ps
 	}
@@ -109,24 +85,7 @@ func (c *Swarm) SomeServices(ids []flux.ServiceID) (res []platform.Service, err 
 			//Status:     string(v.UpdateStatus.State),
 			Containers: platform.ContainersOrExcuse{},
 		}
-		/// OLD
 		args := filters.NewArgs()
-		args.Add("label",
-			fmt.Sprintf("com.docker.swarm.service.name=%v", v.Spec.Annotations.Name),
-		)
-		cs, err := c.client.ContainerList(ctx, types.ContainerListOptions{Filters: args})
-		if err != nil {
-			return pss, err
-		}
-		oldPcs := make([]platform.Container, len(cs))
-		for k, v := range cs {
-			oldPcs[k] = platform.Container{
-				Name:  v.Names[0],
-				Image: v.Image,
-			}
-		}
-		/// NEW
-		args = filters.NewArgs()
 		args.Add("service", v.ID)
 		ts, err := c.client.TaskList(ctx, types.TaskListOptions{Filters: args})
 		if err != nil {
@@ -139,12 +98,6 @@ func (c *Swarm) SomeServices(ids []flux.ServiceID) (res []platform.Service, err 
 				Image: t.Spec.ContainerSpec.Image,
 			}
 		}
-		/// LOG
-		fmt.Printf(
-			"[SomeServices] %s: OLD: %v, NEW: %v\n",
-			v.Spec.Name, oldPcs, pcs,
-		)
-
 		ps.Containers.Containers = pcs
 		pss = append(pss, ps)
 	}

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -31,9 +31,11 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 		if ignore.Contains(ps.ID) {
 			continue
 		}
-		args := filters.NewArgs()
-		args.Add("label", fmt.Sprintf("com.docker.swarm.service.name=%v", v.Spec.Annotations.Name))
 		/// OLD
+		args := filters.NewArgs()
+		args.Add("label",
+			fmt.Sprintf("com.docker.swarm.service.name=%v", v.Spec.Annotations.Name),
+		)
 		cs, err := c.client.ContainerList(ctx, types.ContainerListOptions{Filters: args})
 		if err != nil {
 			return pss, err
@@ -46,6 +48,8 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 			}
 		}
 		/// NEW
+		args = filters.NewArgs()
+		args.Add("service", v.ID)
 		ts, err := c.client.TaskList(ctx, types.TaskListOptions{Filters: args})
 		if err != nil {
 			return pss, err
@@ -105,9 +109,11 @@ func (c *Swarm) SomeServices(ids []flux.ServiceID) (res []platform.Service, err 
 			//Status:     string(v.UpdateStatus.State),
 			Containers: platform.ContainersOrExcuse{},
 		}
-		args := filters.NewArgs()
-		args.Add("label", fmt.Sprintf("com.docker.swarm.service.name=%v", v.Spec.Annotations.Name))
 		/// OLD
+		args := filters.NewArgs()
+		args.Add("label",
+			fmt.Sprintf("com.docker.swarm.service.name=%v", v.Spec.Annotations.Name),
+		)
 		cs, err := c.client.ContainerList(ctx, types.ContainerListOptions{Filters: args})
 		if err != nil {
 			return pss, err
@@ -120,6 +126,8 @@ func (c *Swarm) SomeServices(ids []flux.ServiceID) (res []platform.Service, err 
 			}
 		}
 		/// NEW
+		args = filters.NewArgs()
+		args.Add("service", v.ID)
 		ts, err := c.client.TaskList(ctx, types.TaskListOptions{Filters: args})
 		if err != nil {
 			return pss, err

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -59,7 +59,10 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 		}
 
 		/// LOG
-		fmt.Printf("[AllServices] OLD: %v, NEW: %v\n", oldPcs, pcs)
+		fmt.Printf(
+			"[AllServices] %s: OLD: %v, NEW: %v\n",
+			v.ServiceSpec.Name, oldPcs, pcs,
+		)
 
 		ps.Containers.Containers = pcs
 		pss[k] = ps
@@ -129,7 +132,10 @@ func (c *Swarm) SomeServices(ids []flux.ServiceID) (res []platform.Service, err 
 			}
 		}
 		/// LOG
-		fmt.Printf("[SomeServices] OLD: %v, NEW: %v\n", oldPcs, pcs)
+		fmt.Printf(
+			"[SomeServices] %s: OLD: %v, NEW: %v\n",
+			v.ServiceSpec.Name, oldPcs, pcs,
+		)
 
 		ps.Containers.Containers = pcs
 		pss = append(pss, ps)

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -57,7 +57,7 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 		pcs := make([]platform.Container, len(ts))
 		for k, t := range ts {
 			pcs[k] = platform.Container{
-				Name:  t.Name,
+				Name:  fmt.Sprintf("%s.%d.%s", v.Spec.Name, t.Slot, t.ID),
 				Image: t.Spec.ContainerSpec.Image,
 			}
 		}

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -64,8 +64,8 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 
 		/// LOG
 		fmt.Printf(
-			"[AllServices] %s: OLD: %v, NEW: %v\n",
-			v.Spec.Name, oldPcs, pcs,
+			"[AllServices] %s: OLD: %v, NEW: %v; ts=%v\n",
+			v.Spec.Name, oldPcs, pcs, ts,
 		)
 
 		ps.Containers.Containers = pcs

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -135,7 +135,7 @@ func (c *Swarm) SomeServices(ids []flux.ServiceID) (res []platform.Service, err 
 		pcs := make([]platform.Container, len(ts))
 		for k, t := range ts {
 			pcs[k] = platform.Container{
-				Name:  t.Name,
+				Name:  fmt.Sprintf("%s.%d.%s", v.Spec.Name, t.Slot, t.ID),
 				Image: t.Spec.ContainerSpec.Image,
 			}
 		}

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/ContainerSolutions/flux"
@@ -60,7 +59,7 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 		}
 
 		/// LOG
-		log.Printf("[AllServices] OLD: %v, NEW: %v", oldPcs, pcs)
+		fmt.Printf("[AllServices] OLD: %v, NEW: %v\n", oldPcs, pcs)
 
 		ps.Containers.Containers = pcs
 		pss[k] = ps
@@ -130,7 +129,7 @@ func (c *Swarm) SomeServices(ids []flux.ServiceID) (res []platform.Service, err 
 			}
 		}
 		/// LOG
-		log.Printf("[SomeServices] OLD: %v, NEW: %v", oldPcs, pcs)
+		fmt.Printf("[SomeServices] OLD: %v, NEW: %v\n", oldPcs, pcs)
 
 		ps.Containers.Containers = pcs
 		pss = append(pss, ps)

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -64,7 +64,7 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 
 		/// LOG
 		fmt.Printf(
-			"[AllServices] %s: OLD: %v, NEW: %v; ts=%v\n",
+			"[AllServices] %s: OLD: %v, NEW: %v; ts=%+v\n",
 			v.Spec.Name, oldPcs, pcs, ts,
 		)
 

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -33,15 +33,15 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 		}
 		args := filters.NewArgs()
 		args.Add("label", fmt.Sprintf("com.docker.swarm.service.name=%v", v.Spec.Annotations.Name))
-		cs, err := c.client.ContainerList(ctx, types.ContainerListOptions{Filters: args})
+		ts, err := c.client.TaskList(ctx, types.TaskListOptions{Filters: args})
 		if err != nil {
 			return pss, err
 		}
 		pcs := make([]platform.Container, len(cs))
-		for k, v := range cs {
+		for k, t := range ts {
 			pcs[k] = platform.Container{
-				Name:  v.Labels["com.docker.swarm.task.name"],
-				Image: v.Image,
+				Name:  t.Spec.Annotations.Name,
+				Image: t.Spec.ContainerSpec.Image,
 			}
 		}
 		ps.Containers.Containers = pcs
@@ -87,15 +87,15 @@ func (c *Swarm) SomeServices(ids []flux.ServiceID) (res []platform.Service, err 
 		}
 		args := filters.NewArgs()
 		args.Add("label", fmt.Sprintf("com.docker.swarm.service.name=%v", v.Spec.Annotations.Name))
-		cs, err := c.client.ContainerList(ctx, types.ContainerListOptions{Filters: args})
+		ts, err := c.client.TaskList(ctx, types.TaskListOptions{Filters: args})
 		if err != nil {
 			return pss, err
 		}
 		pcs := make([]platform.Container, len(cs))
-		for k, v := range cs {
+		for k, t := range ts {
 			pcs[k] = platform.Container{
-				Name:  v.Names[0],
-				Image: v.Image,
+				Name:  t.Spec.Annotations.Name,
+				Image: t.Spec.ContainerSpec.Image,
 			}
 		}
 		ps.Containers.Containers = pcs

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/ContainerSolutions/flux"

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -37,10 +37,10 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 		if err != nil {
 			return pss, err
 		}
-		pcs := make([]platform.Container, len(cs))
+		pcs := make([]platform.Container, len(ts))
 		for k, t := range ts {
 			pcs[k] = platform.Container{
-				Name:  t.Spec.Annotations.Name,
+				Name:  t.Name,
 				Image: t.Spec.ContainerSpec.Image,
 			}
 		}
@@ -91,10 +91,10 @@ func (c *Swarm) SomeServices(ids []flux.ServiceID) (res []platform.Service, err 
 		if err != nil {
 			return pss, err
 		}
-		pcs := make([]platform.Container, len(cs))
+		pcs := make([]platform.Container, len(ts))
 		for k, t := range ts {
 			pcs[k] = platform.Container{
-				Name:  t.Spec.Annotations.Name,
+				Name:  t.Name,
 				Image: t.Spec.ContainerSpec.Image,
 			}
 		}

--- a/platform/docker/services.go
+++ b/platform/docker/services.go
@@ -61,7 +61,7 @@ func (c *Swarm) AllServices(namespace string, ignore flux.ServiceIDSet) ([]platf
 		/// LOG
 		fmt.Printf(
 			"[AllServices] %s: OLD: %v, NEW: %v\n",
-			v.ServiceSpec.Name, oldPcs, pcs,
+			v.Spec.Name, oldPcs, pcs,
 		)
 
 		ps.Containers.Containers = pcs
@@ -134,7 +134,7 @@ func (c *Swarm) SomeServices(ids []flux.ServiceID) (res []platform.Service, err 
 		/// LOG
 		fmt.Printf(
 			"[SomeServices] %s: OLD: %v, NEW: %v\n",
-			v.ServiceSpec.Name, oldPcs, pcs,
+			v.Spec.Name, oldPcs, pcs,
 		)
 
 		ps.Containers.Containers = pcs


### PR DESCRIPTION
Currently flux-swarm uses `client.ContainerList`, which is equivalent to `docker ps`. However, this only shows containers on the current host, which makes flux-swarm unable to update services which have containers which are running on different machines to where `fluxd` is running.

This PR updates flux-swarm to use the new `client.TaskList` API, which is equivalent to `docker service ps <service>` which works with docker services, and hence works across multiple hosts.